### PR TITLE
ROC FP TP nan fix if y_true has single unique value

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -613,6 +613,10 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
     array([1.8 , 0.8 , 0.4 , 0.35, 0.1 ])
 
     """
+    if len(np.unique(y_true)) != 2:
+            raise ValueError("Only one class present in y_true. "
+                             "ROC can not be computed in that case.")
+
     fps, tps, thresholds = _binary_clf_curve(
         y_true, y_score, pos_label=pos_label, sample_weight=sample_weight)
 


### PR DESCRIPTION
# FPR becomes `nan`
```
>>> import numpy as np
>>> from sklearn import metrics
>>> y = np.array([1, 1, 1, 1])
>>> scores = np.array([0.1, 0.4, 0.35, 0.8])
>>> fpr, tpr, thresholds = metrics.roc_curve(y, scores)
>>> print(fpr)
[nan nan]
>>> print(tpr)
[0.25 1.  ]
>>> print(thresholds)
[0.8 0.1]
```
# TPR becomes `nan`
```
>>> y = np.array([0, 0, 0, 0])
>>> scores = np.array([0.1, 0.4, 0.35, 0.8])
>>> fpr, tpr, thresholds = metrics.roc_curve(y, scores)
>>> print(fpr)
[0.   0.25 1.  ]
>>> print(tpr)
[nan nan nan]
>>> print(thresholds)
[1.8 0.8 0.1]
```
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
